### PR TITLE
Add dot product demonstration for GPU

### DIFF
--- a/GPU_README.md
+++ b/GPU_README.md
@@ -9,6 +9,7 @@ Return to the [main repository documentation](./README.md).
 [G1 - Allocating memory in CUDA](#gpu_memory)  
 [G2 - Allocating memory in CUDA](#gpu_memcpy)  
 [G3 - Vector x C in CUDA](#gpu_vec_by_c)
+[G4 - Partial Dot Product using Parallel Reduction in CUDA](#gpu_dot_product)
 
 <a id="gpu_memory"></a>
 ## G1 - Memory Allocation using CUDA
@@ -95,4 +96,40 @@ Value of h_b[9] = 4.5
 Value of h_b[10] = 5
 Value of h_b[11] = 5.5
 Value of h_b[12] = 6
+```
+
+<a id="gpu_dot_product"></a>
+## G4 - Partial Dot Product on GPU using Parallel Reduction and CUDA
+
+This example demonstrates the use of parallel reduction on GPU for the computation of a dot product. Here we deliberately return a result early so students can understand how parallel reduction works in GPUs; normally we'd finish the dot product on the device.
+
+The following concepts are covered:
+* Recycling allocation and memory copying functions for general use,
+* Using __syncthreads to sync efforts on the device,
+* Using __shared__ memory on the device for faster temporary storage.
+
+To build and run - navigate to the directory holding this example and type "make", i.e.:
+
+```bash
+cd G_4_Dot_Product/
+make && ./main.exe
+```
+
+### Expected Output
+
+A snippet of the output is shown below:
+
+```bash
+CUDA error (malloc d_a) = no error
+CUDA error (malloc d_a) = no error
+CUDA error (malloc d_a) = no error
+Serial dot product = 1000
+CUDA error (memcpy h_a -> d_a) = no error
+CUDA error (memcpy h_a -> d_a) = no error
+CUDA error (memcpy d_a -> h_b) = no error
+Value of h_z[0] = 256
+Value of h_z[1] = 256
+Value of h_z[2] = 256
+Value of h_z[3] = 232
+GPU Dot Product of h_x and h_y = 1000
 ```

--- a/G_4_Dot_Product/gpu.cu
+++ b/G_4_Dot_Product/gpu.cu
@@ -1,0 +1,75 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#define MAX_BLOCK_SZ 256   	// Maximum number of threads per block
+
+// Device Functions
+
+__global__ void GPU_Partial_Dot_Product(float *x, float *y, float *z, const int n) {
+    __shared__ float temp[MAX_BLOCK_SZ];	
+    int i = blockDim.x*blockIdx.x + threadIdx.x;	// Global index
+    int I = threadIdx.x;							// Local thread index
+    // First, we work out the multiplication phase of the dot product
+    // We will store the result in our "temp" variable in shared memory
+    if (i < n) temp[I] = x[i]*y[i];	
+
+    // Now, we need to syncronize the threads.
+    __syncthreads();
+
+    // Now, we can sum these within this block
+    // We will use a tree structure to perform these additions
+    for (int stride = blockDim.x/2; stride > 0; stride = stride/2) {
+        if (I < stride) {
+            temp[I] += temp[I + stride];
+        }
+        // Force another thread syncronization
+        __syncthreads();
+    }
+
+    // Store the result in z
+    // Each block will store one number
+    if (I == 0) z[blockIdx.x] = temp[0];
+}
+
+// Host Functions
+
+void Allocate_Memory(float **h_a, float **d_a, const char *variable, const int N) {
+    size_t size = N*sizeof(float);
+    cudaError_t Error;
+    // Host memory
+    *h_a = (float*)malloc(size);
+    // Device memory
+    Error = cudaMalloc((void**)d_a, size); 
+    printf("CUDA error (malloc %s) = %s\n", variable, cudaGetErrorString(Error));
+}
+
+void Free_Memory(float **h_a, float **d_a) {
+    if (*h_a) free(*h_a);
+    if (*d_a) cudaFree(*d_a);
+}
+
+void Send_To_Device(float **h_a, float **d_a, const char *variable, const int N) {
+    // Size of data to send
+    size_t size = N*sizeof(float);
+    // Grab a error type
+    cudaError_t Error;
+    // Send A to the GPU
+    Error = cudaMemcpy(*d_a, *h_a, size, cudaMemcpyHostToDevice); 
+    printf("CUDA error (memcpy host -> %s) = %s\n", variable, cudaGetErrorString(Error));
+}
+
+void Get_From_Device(float **d_a, float **h_b, const char *variable, const int N) {
+    // Size of data to send
+    size_t size = N*sizeof(float);
+    // Grab a error type
+    cudaError_t Error;
+    // Send d_a to the host variable h_b
+    Error = cudaMemcpy(*h_b, *d_a, size, cudaMemcpyDeviceToHost);
+    printf("CUDA error (memcpy %s -> host) = %s\n", variable, cudaGetErrorString(Error));
+}
+
+void Partial_Dot_Product(float **d_a, float **d_b, float **d_c, const int N) {
+    int threadsPerBlock = MAX_BLOCK_SZ;
+    int blocksPerGrid = (N + threadsPerBlock - 1) / threadsPerBlock;
+    GPU_Partial_Dot_Product<<<blocksPerGrid, MAX_BLOCK_SZ>>>(*d_a, *d_b, *d_c, N);
+}

--- a/G_4_Dot_Product/gpu.h
+++ b/G_4_Dot_Product/gpu.h
@@ -1,0 +1,10 @@
+/*
+gpu.h
+Declarations of functions used by gpu.cu
+*/
+
+void Allocate_Memory(float **h_a, float **d_a, const char *variable, const int N);
+void Free_Memory(float **h_a, float **d_a);
+void Send_To_Device(float **h_a, float **d_a, const char *variable, const int N);
+void Get_From_Device(float **d_a, float **h_b, const char *variable, const int N);
+void Partial_Dot_Product(float **d_a, float **d_b, float **d_c, const int N);

--- a/G_4_Dot_Product/main.c
+++ b/G_4_Dot_Product/main.c
@@ -1,0 +1,58 @@
+#include <stdio.h>
+#include "gpu.h"
+
+#define MAX_BLOCK_SZ 256   	// Maximum number of threads per block
+
+int main(int argc, char *argv[]) {
+
+    float *h_x;	// Host variables
+    float *h_y;
+    float *h_z;
+    float *d_x;	// Device variables
+    float *d_y;
+    float *d_z;
+    float dot_sum = 0.0;
+    const int N = 1000;	
+    int blocksPerGrid = (N + MAX_BLOCK_SZ - 1) / MAX_BLOCK_SZ;		// Number of blocks
+    int i;
+
+    // Allocate memory on both device and host for x, y and z
+    Allocate_Memory(&h_x, &d_x, "d_x", N);
+    Allocate_Memory(&h_y, &d_y, "d_y", N);
+    Allocate_Memory(&h_z, &d_z, "d_z", blocksPerGrid);
+
+    // Initialise x and y; compute the dot product now to check the result
+    for (i = 0; i < N; i++) {
+        h_x[i] = 1.0;
+        h_y[i] = 1.0;
+        dot_sum += h_x[i]*h_y[i];
+    }
+
+    printf("Serial dot product = %g\n", dot_sum);
+    dot_sum = 0.0; // Reset for GPU test
+
+    // Send x and y to the device
+    Send_To_Device(&h_x, &d_x, "d_x", N);
+    Send_To_Device(&h_y, &d_y, "d_y", N);
+
+    // Perform a computation - Partial Dot Product
+    Partial_Dot_Product(&d_x, &d_y, &d_z, N);
+
+    // Copy d_z from the device into h_z on the host
+    Get_From_Device(&d_z, &h_z, "d_z", blocksPerGrid);
+
+    // Check the values of h_z; sum these to get the dot product
+    for (i = 0; i < blocksPerGrid; i++) {
+        printf("Value of h_z[%d] = %g\n", i, h_z[i]);
+        dot_sum += h_z[i];
+    }
+
+    printf("GPU Dot Product of h_x and h_y = %g\n", dot_sum);
+
+    // Free memory
+    Free_Memory(&h_x, &d_x);
+    Free_Memory(&h_y, &d_y);
+    Free_Memory(&h_z, &d_z);
+
+    return 0;
+}

--- a/G_4_Dot_Product/makefile
+++ b/G_4_Dot_Product/makefile
@@ -1,0 +1,8 @@
+all: GPU CPU
+	nvcc main.o gpu.o -arch=compute_80 -o main.exe
+GPU:
+	nvcc gpu.cu -c -arch=compute_80 
+CPU:
+	g++ main.c -c
+clean:
+	rm *.o main.exe


### PR DESCRIPTION
This represents quite a large leap from G3; the computation of a dot product which is MOSTLY done on the device. This aims to demonstrate the use of syncthreads and shared memory on the device, and help students understand the role thread blocks play in parallel reduction.